### PR TITLE
Add links to GHs and LI profiles for everyone

### DIFF
--- a/src/Components/ContactUs/ContactUs.js
+++ b/src/Components/ContactUs/ContactUs.js
@@ -1,4 +1,5 @@
 import "../ContactUs/ContactUs.css";
+import { Link } from "react-router-dom";
 
 const LandingPage = () => {
   return (
@@ -17,32 +18,71 @@ const LandingPage = () => {
           <div className="contact-title">RANA</div>
           <div className="contact-underline"></div>
           <button className="contact-button">EMAIL</button>
-          <button className="contact-button">LINKEDIN</button>
-          <button className="contact-button">GITHUB</button>
+          <Link
+            to={{ pathname: "https://www.linkedin.com/in/rana-jurjus/" }}
+            target="_blank"
+          >
+            <button className="contact-button">LINKEDIN</button>
+          </Link>
+          <Link to={{ pathname: "https://github.com/rjur11/" }} target="_blank">
+            <button className="contact-button">GITHUB</button>
+          </Link>
         </div>
         <div className="contact-card">
           <div className="contact-photo" alt="contact Photo"></div>
           <div className="contact-title">DANIEL</div>
           <div className="contact-underline"></div>
           <button className="contact-button">EMAIL</button>
-          <button className="contact-button">LINKEDIN</button>
-          <button className="contact-button">GITHUB</button>
+          <Link
+            to={{
+              pathname: "https://www.linkedin.com/in/daniel-o-connell-maker/",
+            }}
+            target="_blank"
+          >
+            <button className="contact-button">LINKEDIN</button>
+          </Link>
+          <Link
+            to={{ pathname: "https://github.com/Daniel-OC" }}
+            target="_blank"
+          >
+            <button className="contact-button">GITHUB</button>
+          </Link>
         </div>
         <div className="contact-card">
           <div className="contact-photo" alt="contact Photo"></div>
           <div className="contact-title">TONY</div>
           <div className="contact-underline"></div>
           <button className="contact-button">EMAIL</button>
-          <button className="contact-button">LINKEDIN</button>
-          <button className="contact-button">GITHUB</button>
+          <Link
+            to={{ pathname: "https://www.linkedin.com/in/tony-carpenter/" }}
+            target="_blank"
+          >
+            <button className="contact-button">LINKEDIN</button>
+          </Link>
+          <Link
+            to={{ pathname: "https://github.com/tonycarpenter21" }}
+            target="_blank"
+          >
+            <button className="contact-button">GITHUB</button>
+          </Link>
         </div>
         <div className="contact-card">
           <div className="contact-photo" alt="contact Photo"></div>
           <div className="contact-title">THOMAS</div>
           <div className="contact-underline"></div>
           <button className="contact-button">EMAIL</button>
-          <button className="contact-button">LINKEDIN</button>
-          <button className="contact-button">GITHUB</button>
+          <Link
+            to={{ pathname: "https://www.linkedin.com/in/tommi-t-nguyen/" }}
+            target="_blank"
+          >
+            <button className="contact-button">LINKEDIN</button>
+          </Link>
+          <Link
+            to={{ pathname: "https://github.com/tommi-t-nguyen" }}
+            target="_blank"
+          >
+            <button className="contact-button">GITHUB</button>
+          </Link>
         </div>
       </div>
       <h1 className="contact-header">BACK END TEAM:</h1>
@@ -52,32 +92,71 @@ const LandingPage = () => {
           <div className="contact-title">Hannah</div>
           <div className="contact-underline"></div>
           <button className="contact-button">EMAIL</button>
-          <button className="contact-button">LINKEDIN</button>
-          <button className="contact-button">GITHUB</button>
+          <Link
+            to={{ pathname: "https://www.linkedin.com/in/hannahkwarren/" }}
+            target="_blank"
+          >
+            <button className="contact-button">LINKEDIN</button>
+          </Link>
+          <Link
+            to={{ pathname: "https://github.com/hannahkwarren" }}
+            target="_blank"
+          >
+            <button className="contact-button">GITHUB</button>
+          </Link>
         </div>
         <div className="contact-card">
           <div className="contact-photo" alt="contact Photo"></div>
           <div className="contact-title">Chris</div>
           <div className="contact-underline"></div>
           <button className="contact-button">EMAIL</button>
-          <button className="contact-button">LINKEDIN</button>
-          <button className="contact-button">GITHUB</button>
+          <Link
+            to={{
+              pathname: "https://www.linkedin.com/in/chris-hewitt-78721b21b/",
+            }}
+            target="_blank"
+          >
+            <button className="contact-button">LINKEDIN</button>
+          </Link>
+          <Link
+            to={{ pathname: "https://github.com/Henchworm" }}
+            target="_blank"
+          >
+            <button className="contact-button">GITHUB</button>
+          </Link>
         </div>
         <div className="contact-card">
           <div className="contact-photo" alt="contact Photo"></div>
           <div className="contact-title">David</div>
           <div className="contact-underline"></div>
           <button className="contact-button">EMAIL</button>
-          <button className="contact-button">LINKEDIN</button>
-          <button className="contact-button">GITHUB</button>
+          <Link
+            to={{ pathname: "https://www.linkedin.com/in/david-kassin/" }}
+            target="_blank"
+          >
+            <button className="contact-button">LINKEDIN</button>
+          </Link>
+          <Link to={{ pathname: "https://github.com/dkassin" }} target="_blank">
+            <button className="contact-button">GITHUB</button>
+          </Link>
         </div>
         <div className="contact-card">
           <div className="contact-photo" alt="contact Photo"></div>
           <div className="contact-title">Jackson</div>
           <div className="contact-underline"></div>
           <button className="contact-button">EMAIL</button>
-          <button className="contact-button">LINKEDIN</button>
-          <button className="contact-button">GITHUB</button>
+          <Link
+            to={{ pathname: "https://www.linkedin.com/in/valdez-jackson/" }}
+            target="_blank"
+          >
+            <button className="contact-button">LINKEDIN</button>
+          </Link>
+          <Link
+            to={{ pathname: "https://github.com/jacksonvaldez" }}
+            target="_blank"
+          >
+            <button className="contact-button">GITHUB</button>
+          </Link>
         </div>
       </div>
       <br />


### PR DESCRIPTION
- Commit message(s) added to this PR:
  - Add links to GHs and LI profiles for everyone
  
- Why is this change necessary (explain like I'm 5)?
  - Just adding links and redirects to contact page profile cards
  
- What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
  - not much. Just added links
  
- Why did we make this change? What Changed? How do we test it?
  - We wanted a way to navigate to personal githubs and linkedins, so we added links to each button
  - Cypress can probably test that these buttons on click go to the expected URLs but this is past MVP