### PR TITLE
Feature/add individual room query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ruum",
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.5.10",
@@ -22210,7 +22211,9 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -26767,7 +26770,9 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -29452,6 +29457,7 @@
         "is-glob": "^4.0.3",
         "normalize-path": "^3.0.0",
         "object-hash": "^2.2.0",
+        "postcss": "^8.4.6",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.0",
         "postcss-nested": "5.0.6",
@@ -30093,7 +30099,9 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",
@@ -30173,7 +30181,9 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-          "requires": {}
+          "requires": {
+            "ajv": "^8.0.0"
+          }
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/src/Components/RenterResultCard/RenterResultCard.js
+++ b/src/Components/RenterResultCard/RenterResultCard.js
@@ -38,7 +38,7 @@ const RenterResultCard = (props) => {
             </div>
           </div>
           <div className="button-container">
-            <Link to="/booking/1">
+            <Link to={`/booking/${props.id}`}>
               <button className="more-details-button">SEE DETAILS</button>
             </Link>
             <Link to="/dashboard">

--- a/src/Components/RenterResultsContainer/RenterResultsContainer.js
+++ b/src/Components/RenterResultsContainer/RenterResultsContainer.js
@@ -13,6 +13,7 @@ const RenterResultsContainer = (props) => {
             amenities={card.amenities}
             rating={card.rating}
             price={card.price}
+            id={card.id}
           />
         );
       })}

--- a/src/Components/RoomView/RoomView.js
+++ b/src/Components/RoomView/RoomView.js
@@ -1,7 +1,14 @@
 import "./RoomView.css";
 import auditorium from "../../Images/auditorium.png";
 import { Link } from "react-router-dom";
-const RoomView = () => {
+import {getIndividualRoom} from "../../queries";
+import {useQuery} from '@apollo/client';
+
+const RoomView = (props) => {
+  const {loading, data} = useQuery(getIndividualRoom(props.id))
+  console.log(props.id)
+  console.log(data)
+
   return (
     <div className="detailed-view-container">
       <div className="detailed-view-card">
@@ -14,16 +21,15 @@ const RoomView = () => {
           <div className="detailed-view-info">
             <div className="detailed-view-top-info">
               <div className="detailed-view-room-name-info">
-                <p className="detailed-view-info-title room-title">Jeff's House</p>
-                <p className="detailed-view-specific-room-name room-text">Main Auditorium</p>
+                <p className="detailed-view-info-title room-title">{data.getRoom.name}</p>
               </div>
-              <div className="detailed-view-ratings-info">
+              {/* <div className="detailed-view-ratings-info">
                 <div className="detailed-view-info-title ratings-title">Ratings:</div>
                 <div className="detailed-view-ratings-value ratings-text">4.2/5</div>
-              </div>
+              </div> */}
               <div className="detailed-view-price-info">
                 <div className="detailed-view-info-title price-title">Price:</div>
-                <div className="detailed-view-rental-price price-text">$85</div>
+                <div className="detailed-view-rental-price price-text">${data.getRoom.price}</div>
               </div>
 
               <div className="detailed-view-available-instruments-info">
@@ -31,27 +37,20 @@ const RoomView = () => {
                   Available Instruments:
                 </div>
                 <div className="detailed-view-instruments-list instrument-text">
-                  Piano, Drums, Kazoo, French Horn
+                  {data.getRoom.instruments}
                 </div>
               </div>
               <div className="detailed-view-amenity-info">
                 <div className="detailed-view-info-title amenities-title">Amenities:</div>
                 <div className="detailed-view-amenity-list amenities-text">
-                  Bathroom, WiFi, AC/Heat
+                  {data.getRoom.amenities}
                 </div>
               </div>
             </div>
             <div className="detailed-view-bottom-info">
               <div className="detailed-view-info-title description-title">Full Description:</div>
               <div className="detailed-view-amenity-list description-text">
-                Jeff's House is the optimal place to record your next album.
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-                enim ad minim veniam, quis nostrud exercitation ullamco laboris
-                nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-                in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-                sunt in culpa qui officia deserunt mollit anim id est laborum.
+                {data.getRoom.details}
               </div>
             </div>
           </div>

--- a/src/Pages/Booking/Booking.js
+++ b/src/Pages/Booking/Booking.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import RoomView from '../../Components/RoomView/RoomView'
 
-const Booking = () => {
+const Booking = (props) => {
   return (
     <div>
-      <RoomView/>
+      <RoomView id={props.id}/>
     </div>
   )
 }

--- a/src/Pages/Search/Search.js
+++ b/src/Pages/Search/Search.js
@@ -1,7 +1,7 @@
 import React from "react";
 import RenterResultsContainer from "../../Components/RenterResultsContainer/RenterResultsContainer";
 import ResultsFilterBar from "../../Components/ResultsFilterBar/ResultsFilterBar";
-import getRoomsByDate from "../../queries";
+import {getRoomsByDate} from "../../queries";
 import { useState } from "react";
 import { useQuery } from "@apollo/client";
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,15 +1,33 @@
 import {gql} from "@apollo/client"
 
 const getRoomsByDate = (date) => gql`
-      {
-        getAvailableRooms(date: "${date}") {
-          id
-          name
-          photo
-          price
-          amenities
-          instruments
-          }
-      }`
+  {
+    getAvailableRooms(date: "${date}") {
+      id
+      name
+      photo
+      price
+      amenities
+      instruments
+      }
+  }`
+
+const getIndividualRoom = (id) => gql`
+  {
+    getRoom(id: "${id}") {
+      id
+      name
+      details
+      photo
+      address
+      city
+      state
+      zip
+      price
+      amenities
+      instruments
+      capacity
+      }
+  }`
   
-export default getRoomsByDate;
+export {getRoomsByDate, getIndividualRoom};


### PR DESCRIPTION
- Commit message(s) added to this PR:
  - [Update individual room view to rely on graphql request](https://github.com/Rum-Project/ruum-fe/commit/4f3ab4187b19a9dda63c757ca509322b93022703)
  - [Update the importing of queries to function now that there are multip…](https://github.com/Rum-Project/ruum-fe/commit/d191cabaf26eef45f90ee3edfc7014b20ef96162)
  - [Write a query for individual room details](https://github.com/Rum-Project/ruum-fe/commit/477a68c2292533c2a1873f28933be0f14d6c9d2e)

- Why is this change necessary (explain like I'm 5)?
  - We needed to hook the front end to the back end for the individual room view, we did this by writing a query to dynamically grab a room by id number, and display it in the room view component 

- What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
  - The dummy data on Room view was cut out, and replaced with the response from a graphql query that is placed at the top of the component. 
  - Now when you click on an individual room from the initial "search" view, you should see data that accurately represents the room you clicked on, and no errors in the console

