### PR TITLE
Feature/add get musician bookings

### DIFF
--- a/src/Components/RenterBookingCard/RenterBookingCard.js
+++ b/src/Components/RenterBookingCard/RenterBookingCard.js
@@ -1,7 +1,12 @@
 import "./RenterBookingCard.css";
 import housepic from "../../Images/house.png";
 
-const RenterBookingCard = () => {
+const RenterBookingCard = ({booking}) => {
+
+  const formatDate = (date) => {
+    return new Date(date).toLocaleDateString('en-us')
+  }
+
   return (
     <div className="booking-card">
       <img src={housepic} className="house-photo" alt="room" />
@@ -9,28 +14,27 @@ const RenterBookingCard = () => {
         <div className="booking-card-info-and-button-container">
           <div className="info-container">
             <div className="top-info">
-              <p className="card-title room-title">Jeff's House</p>
-              <p className="card-text room-text">Main Auditorium</p>
+              <p className="card-title room-title">{booking.room.name}</p>
             </div>
             <div className="bottom-info">
               <p className="card-title instrument-title">Available Instruments:</p>
-              <p className="card-text instrument-text">Piano, Drums, Kazoo, French Horn</p>
+              <p className="card-text instrument-text">{booking.room.instruments}</p>
             </div>
           </div>
           <div className="info-container">
             <div className="top-info">
               <p className="card-title amenities-title">Amenities:</p>
-              <p className="card-text amenities-text">Bathroom, WiFi, AC/Heat</p>
+              <p className="card-text amenities-text">{booking.room.amenities}</p>
             </div>
           </div>
           <div className="info-container">
             <div className="top-info">
               <p className="card-title date-title">Date:</p>
-              <p className="card-text date-text">3/28/2022</p>
+              <p className="card-text date-text">{formatDate(booking.date)}</p>
             </div>
             <div className="bottom-info">
               <p className="card-title price-title">Price:</p>
-              <p className="card-text price-text">$85</p>
+              <p className="card-text price-text">${booking.room.price.toFixed(2)}</p>
             </div>
           </div>
           <button className="cancel-button">CANCEL BOOKING</button>

--- a/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
+++ b/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
@@ -19,7 +19,7 @@ const RenterBookingsContainer = (props) => {
         return 0;
       }
     });
-    return futureBookings.map(booking => {return <RenterBookingCard booking={booking}/>})
+    return futureBookings.map((booking, index) => {return <RenterBookingCard key={index} booking={booking}/>})
     
   }
 

--- a/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
+++ b/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
@@ -1,17 +1,37 @@
 import "./RenterBookingsContainer.css";
 import RenterBookingCard from "../RenterBookingCard/RenterBookingCard";
 
-const RenterBookingsContainer = () => {
+const RenterBookingsContainer = (props) => {
+
+  const getFutureBookings = () => {
+    const today = new Date(new Date().toDateString());
+    const futureBookings = props.bookings.filter((booking) => {
+      return new Date(booking.date) > today;
+    });
+    futureBookings.sort((a, b) => {
+      a = new Date(a.date);
+      b = new Date(b.date);
+      if (a < b) {
+        return -1;
+      } else if (b < a) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+    return futureBookings.map(booking => {return <RenterBookingCard booking={booking}/>})
+    
+  }
+
   return (
     <div className="results-container">
       <h2>Upcoming Bookings:</h2>
-      <RenterBookingCard />
-      <RenterBookingCard />
+      {getFutureBookings()}
       <h2>Past Bookings:</h2>
+      {/* <RenterBookingCard />
       <RenterBookingCard />
       <RenterBookingCard />
-      <RenterBookingCard />
-      <RenterBookingCard />
+      <RenterBookingCard /> */}
     </div>
   );
 };

--- a/src/Components/RoomView/RoomView.js
+++ b/src/Components/RoomView/RoomView.js
@@ -5,62 +5,63 @@ import {getIndividualRoom} from "../../queries";
 import {useQuery} from '@apollo/client';
 
 const RoomView = (props) => {
-  const {loading, data} = useQuery(getIndividualRoom(props.id))
+  const {loading, data, error} = useQuery(getIndividualRoom(props.id))
   console.log(props.id)
-  console.log(data)
+  console.log(loading, data, error)
 
   return (
-    <div className="detailed-view-container">
-      <div className="detailed-view-card">
-        <img
-          src={auditorium}
-          className="detailed-view-photo"
-          alt="detailed-room-view"
-        />
-        <div className="below-image">
-          <div className="detailed-view-info">
-            <div className="detailed-view-top-info">
-              <div className="detailed-view-room-name-info">
-                <p className="detailed-view-info-title room-title">{data.getRoom.name}</p>
+    <>
+    {loading ? (
+      <h1>Loading...</h1>
+    ) : (
+      <div className="detailed-view-container">
+        <div className="detailed-view-card">
+          <img
+            src={auditorium}
+            className="detailed-view-photo"
+            alt="detailed-room-view"
+          />
+          <div className="below-image">
+            <div className="detailed-view-info">
+              <div className="detailed-view-top-info">
+                <div className="detailed-view-room-name-info">
+                  <p className="detailed-view-info-title room-title">{data.getRoom.name}</p>
+                </div>
+                <div className="detailed-view-price-info">
+                  <div className="detailed-view-info-title price-title">Price:</div>
+                  <div className="detailed-view-rental-price price-text">${data.getRoom.price}</div>
+                </div>
+                <div className="detailed-view-available-instruments-info">
+                  <div className="detailed-view-info-title instrument-title">
+                    Available Instruments:
+                  </div>
+                  <div className="detailed-view-instruments-list instrument-text">
+                    {data.getRoom.instruments}
+                  </div>
+                </div>
+                <div className="detailed-view-amenity-info">
+                  <div className="detailed-view-info-title amenities-title">Amenities:</div>
+                  <div className="detailed-view-amenity-list amenities-text">
+                    {data.getRoom.amenities}
+                  </div>
+                </div>
               </div>
-              {/* <div className="detailed-view-ratings-info">
-                <div className="detailed-view-info-title ratings-title">Ratings:</div>
-                <div className="detailed-view-ratings-value ratings-text">4.2/5</div>
-              </div> */}
-              <div className="detailed-view-price-info">
-                <div className="detailed-view-info-title price-title">Price:</div>
-                <div className="detailed-view-rental-price price-text">${data.getRoom.price}</div>
+              <div className="detailed-view-bottom-info">
+                <div className="detailed-view-info-title description-title">Full Description:</div>
+                <div className="detailed-view-amenity-list description-text">
+                  {data.getRoom.details}
+                </div>
               </div>
+            </div>
 
-              <div className="detailed-view-available-instruments-info">
-                <div className="detailed-view-info-title instrument-title">
-                  Available Instruments:
-                </div>
-                <div className="detailed-view-instruments-list instrument-text">
-                  {data.getRoom.instruments}
-                </div>
-              </div>
-              <div className="detailed-view-amenity-info">
-                <div className="detailed-view-info-title amenities-title">Amenities:</div>
-                <div className="detailed-view-amenity-list amenities-text">
-                  {data.getRoom.amenities}
-                </div>
-              </div>
-            </div>
-            <div className="detailed-view-bottom-info">
-              <div className="detailed-view-info-title description-title">Full Description:</div>
-              <div className="detailed-view-amenity-list description-text">
-                {data.getRoom.details}
-              </div>
-            </div>
+            <Link to="/dashboard">
+              <button className="book-now-button">BOOK NOW</button>
+            </Link>
           </div>
-
-          <Link to="/dashboard">
-            <button className="book-now-button">BOOK NOW</button>
-          </Link>
         </div>
       </div>
-    </div>
+    )}
+    </>
   );
 };
 

--- a/src/Pages/Dashboard/Dashboard.js
+++ b/src/Pages/Dashboard/Dashboard.js
@@ -1,10 +1,21 @@
 import React from "react";
 import RenterBookingsContainer from "../../Components/RenterBookingsContainer/RenterBookingsContainer";
+import { getBookingsForMusician } from "../../queries";
+import { useQuery } from "@apollo/client";
+
 
 const Dashboard = () => {
+  const {loading, data, error} = useQuery(getBookingsForMusician(1))//LONGTERM FIGURE OUT HOW TO MAKE THIS DYNAMIC ACCORDING TO LOG IN INFO!
+
+  console.log(loading,data, error)
+
   return (
     <>
-      <RenterBookingsContainer />
+    {loading ?
+    (<h1>Loading...</h1>)
+    :
+    (<RenterBookingsContainer bookings={data.getMusicianBookings} />)
+    }
     </>
   );
 };

--- a/src/queries.js
+++ b/src/queries.js
@@ -29,5 +29,29 @@ const getIndividualRoom = (id) => gql`
       capacity
       }
   }`
+
+const getBookingsForMusician = (musicianId) => gql`
+  { getMusicianBookings(id: "${musicianId}")
+        {
+          date
+          room {
+            id
+            name
+            host {
+              name
+            }
+            details
+            photo
+            address
+            city
+            state
+            zip
+            price
+            amenities
+            instruments
+            capacity
+          }
+        }
+      }`
   
-export {getRoomsByDate, getIndividualRoom};
+export {getRoomsByDate, getIndividualRoom, getBookingsForMusician};


### PR DESCRIPTION
- Commit message(s) added to this PR:
  - [Cleaned up logic in Room View to account for loading](https://github.com/Rum-Project/ruum-fe/commit/28fd12db6053f6a793eb6dd26289452fe2a60768)
  - [Write getBookingsForMusician query](https://github.com/Rum-Project/ruum-fe/commit/73c63dea030c5269aa0aa6f8aa90c0f6171fbdeb)
  - [Set up the bookings page to reflect the backend data for musician 1](https://github.com/Rum-Project/ruum-fe/commit/61c7d99efdc82f45b3155fbb4198cdd8020ffff2)
  
- Why is this change necessary (explain like I'm 5)?
  - We needed to set up the bookings page to pull real data from the backend, this series of changes does so
  - It is currently limited to upcoming bookings because there are no past bookings in the seed data, this is something we will need to request of the backend team ASAP 

- What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
  - A query was added to the queries file for pulling the bookings for a single musician based off of musician ID 
  - The logic was added to query the graphql endpoint and fill the bookings data with it's results
  - When you go to the bookings page, it should currently load two cards with the two existing bookings for musician 1. There should be no console errors
