### PR TITLE
Feature/add booking mutation to details view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,47 +12,24 @@ import Error from "./Pages/Error/Error.js";
 import NavBar from "./Components/Navbar/NavBar.js";
 import Footer from "./Components/Footer/Footer.js";
 import { Route, Switch, Redirect } from "react-router-dom";
+import { useState } from "react";
 import "./App.css";
 
 function App() {
-  let rooms = [
-    {
-      title: "Jeff's Auditiorium",
-      room: "TV Room",
-      availableInstruments: "Piano",
-      amenities: "Wifi",
-      rating: "4.5/5",
-      price: 85,
-    },
-    {
-      title: "Tony's Study",
-      room: "Computer Room",
-      availableInstruments: "Drums",
-      amenities: "Drinking Water",
-      rating: "5/5",
-      price: 60,
-    },
-    {
-      title: "Daniel's Kitchen",
-      room: "Kitchen",
-      availableInstruments: "none",
-      amenities: "Drinking Water",
-      rating: "5/5",
-      price: 102,
-    },
-  ];
+  const [date, setDate] = useState(new Date(new Date().toLocaleDateString()).toJSON());
+
 
   return (
     <main className="App">
       <NavBar />
       <Switch>
         <Route exact path="/" render={() => <Home />} />
-        <Route exact path="/search" render={() => <Search />} />
+        <Route exact path="/search" render={() => <Search date={date} setDate={setDate}/>} />
 
         <Route
           exact
           path="/booking/:id"
-          render={({ match }) => <Booking id={match.params.id} />}
+          render={({ match }) => <Booking id={match.params.id} date={date}/>}
         />
         <Route exact path="/dashboard" render={() => <Dashboard />} />
         <Route

--- a/src/Components/RoomView/RoomView.js
+++ b/src/Components/RoomView/RoomView.js
@@ -1,7 +1,24 @@
 import "./RoomView.css";
 import { Link } from "react-router-dom";
+import { useMutation } from "@apollo/client";
+import { createNewBooking, getBookingsForMusician, getRoomsByDate } from "../../queries";
 
-const RoomView = ({ room }) => {
+
+const RoomView = ({ room, date }) => {
+
+  // const navigateToBookings = () => {
+  //   createBooking({ variables: createTestObject()})
+  // }
+
+  const [createBooking, {data, loading, error}] = useMutation(createNewBooking, {
+    refetchQueries:[{
+      query:getBookingsForMusician(2)}, {query:getRoomsByDate(date)}]
+  })
+  const createTestObject = () => {
+    return {date: `${date}`, musicianId: "2", roomId: `${room.id}`}
+  }
+  
+  console.log(date)
   return (
     <>
       <div className="detailed-view-container">
@@ -55,7 +72,7 @@ const RoomView = ({ room }) => {
             </div>
 
             <Link to="/dashboard">
-              <button className="book-now-button">BOOK NOW</button>
+              <button className="book-now-button" onClick={() => createBooking({ variables: createTestObject()})}>BOOK NOW</button>
             </Link>
           </div>
         </div>

--- a/src/Pages/Booking/Booking.js
+++ b/src/Pages/Booking/Booking.js
@@ -12,7 +12,7 @@ const Booking = (props) => {
       {loading ? (
         <h1>Loading...</h1>
       ) :
-      (<RoomView room={data.getRoom}/>
+      (<RoomView room={data.getRoom} date={props.date}/>
     )}
     </>
   )

--- a/src/Pages/Search/Search.js
+++ b/src/Pages/Search/Search.js
@@ -5,16 +5,16 @@ import { getRoomsByDate } from "../../queries";
 import { useState } from "react";
 import { useQuery } from "@apollo/client";
 
-const Search = () => {
-  const [date, setDate] = useState(new Date(new Date().toLocaleDateString()).toJSON());
-  const { loading, data, error } = useQuery(getRoomsByDate(date));
+const Search = (props) => {
+  // const [date, setDate] = useState(new Date(new Date().toLocaleDateString()).toJSON());
+  const { loading, data, error } = useQuery(getRoomsByDate(props.date));
   const [availableInstSelect, setAvailableInstSelect] = useState([]);
   const [availableAmenSelect, setAvailableAmenSelect] = useState([]);
   const [sortSelect, setSortSelect] = useState({
     value: "High-to-Low",
     label: "Cost High-to-Low",
   });
-  console.log(new Date(date).toISOString())
+
   let rooms = [];
   if (!loading) {
     rooms = data.getAvailableRooms
@@ -42,8 +42,8 @@ const Search = () => {
   return (
     <>
       <ResultsFilterBar
-        date={date}
-        setDate={setDate}
+        date={props.date}
+        setDate={props.setDate}
         availableInstruments={availableInstSelect}
         onAvailableInstrumentsChange={setAvailableInstSelect}
         availableAmenities={availableAmenSelect}
@@ -51,7 +51,7 @@ const Search = () => {
         sortSelect={sortSelect}
         onSortChange={setSortSelect}
       />
-      {loading ? <h1>Loading...</h1> : <RenterResultsContainer date={date} rooms={rooms} />}
+      {loading ? <h1>Loading...</h1> : <RenterResultsContainer date={props.date} rooms={rooms} />}
     </>
   );
 };


### PR DESCRIPTION
- Commit message(s) added to this PR:
  - [Move the date piece of state up into App so that it's available for b…](https://github.com/Rum-Project/ruum-fe/commit/dcf9a3fb4838c0fb26306aabc2d20ac625a12f7a)
  -  [Pass date through Booking down to roomview](https://github.com/Rum-Project/ruum-fe/commit/94c074bc7cc057c35fdb8b625c4533ab63bc9fd7)
  - [Add createBooking method to Roomview to allow for creation of booking…](https://github.com/Rum-Project/ruum-fe/commit/a07427fa23a0315aad127779c06fdbbd43b3611a)

- Why is this change necessary (explain like I'm 5)?
  - We Needed the ability to create a booking from the "detailed" room view page
  - In order to do this we needed to move the "date" piece of state up a level in the component architecture, allowing it to be passed down through booking to room view 

- What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
  - Date was moved out of search and into app, and passed down through search and booking
  - When you go to a detailed room view, you should be able to create a booking for a future date, and it should appear under "upcoming bookings" 

