### PR TITLE
Feature/display past bookings

### DIFF
--- a/cypress/integration/musician-flow-spec.js
+++ b/cypress/integration/musician-flow-spec.js
@@ -1,4 +1,4 @@
-import { aliasQuery } from "../../src/Utils/graphql-test-utils";
+import { aliasQuery, aliasMutation } from "../../src/Utils/graphql-test-utils";
 
 describe("Musician Music Flow", () => {
   beforeEach(() => {
@@ -8,7 +8,7 @@ describe("Musician Music Flow", () => {
       (req) => {
         aliasQuery(req, "getAvailableRooms", "roomcardFixture.json");
         aliasQuery(req, "getRoom", "roomDetailsFixture.json");
-        // aliasMutation(req, "getMusicianBookings", "bookingsFixture.json")
+        aliasQuery(req, "getMusicianBookings", "bookingsFixture.json")
 
         // req.reply({ statusCode: 200, fixture: "roomcardFixture.json" });
       }
@@ -106,34 +106,31 @@ describe("Musician Music Flow", () => {
       .should("exist")
       .get(".room-title")
       .first()
-      .should("have.text", "Jeff's House")
-      .get(".room-text")
-      .first()
-      .should("have.text", "Main Auditorium")
+      .should("have.text", "Amphitheater 2")
       .get(".instrument-title")
       .first()
       .should("have.text", "Available Instruments:")
       .get(".instrument-text")
       .first()
-      .should("have.text", "Piano, Drums, Kazoo, French Horn")
+      .should("have.text", "trumpet")
       .get(".amenities-title")
       .first()
       .should("have.text", "Amenities:")
       .get(".amenities-text")
       .first()
-      .should("have.text", "Bathroom, WiFi, AC/Heat")
+      .should("have.text", "wifi, bathrooms, drinking water")
       .get(".date-title")
       .first()
       .should("have.text", "Date:")
       .get(".date-text")
       .first()
-      .should("have.text", "3/28/2022")
+      .should("have.text", "2022-04-30 00:00:00 UTC")
       .get(".price-title")
       .first()
       .should("have.text", "Price:")
       .get(".price-text")
       .first()
-      .should("have.text", "$85")
+      .should("have.text", "$37.29")
       .get(".cancel-button")
       .should("exist"); //THIS NEEDS TO BE CHANGED THE SECOND THAT CANCEL BOOKING DOES ANYTHING
   });

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,6 @@ import "./App.css";
 
 function App() {
   const [date, setDate] = useState(new Date(new Date().toLocaleDateString()).toJSON().slice(0,10));
-  console.log(date)
 
   return (
     <main className="App">

--- a/src/Components/RenterBookingCard/RenterBookingCard.js
+++ b/src/Components/RenterBookingCard/RenterBookingCard.js
@@ -1,16 +1,15 @@
 import "./RenterBookingCard.css";
-import housepic from "../../Images/house.png";
 import { useMutation } from "@apollo/client";
 import { deleteBooking, getBookingsForMusician, getRoomsByDate } from "../../queries";
 
 const RenterBookingCard = ({ booking }) => {
-  const formatDate = (date) => {
-    return new Date(date).toLocaleDateString("en-us");
-  };
+  // const formatDate = (date) => {
+  //   return new Date(date).toLocaleDateString("en-us");
+  // };
   const handleClick = () => {
     destroyBooking({variables: createDelete()})
   }
-  const [destroyBooking, {data, loading, error}] = useMutation(deleteBooking, {
+  const [destroyBooking, {}] = useMutation(deleteBooking, {
     refetchQueries:[{
       query:getBookingsForMusician(2)}, {query:getRoomsByDate(booking.date.slice(0,10))}]
   })

--- a/src/Components/RenterBookingCard/RenterBookingCard.js
+++ b/src/Components/RenterBookingCard/RenterBookingCard.js
@@ -9,7 +9,7 @@ const RenterBookingCard = ({ booking }) => {
   const handleClick = () => {
     destroyBooking({variables: createDelete()})
   }
-  const [destroyBooking, {}] = useMutation(deleteBooking, {
+  const [destroyBooking] = useMutation(deleteBooking, {
     refetchQueries:[{
       query:getBookingsForMusician(2)}, {query:getRoomsByDate(booking.date.slice(0,10))}]
   })

--- a/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
+++ b/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
@@ -22,17 +22,33 @@ const RenterBookingsContainer = (props) => {
     return futureBookings.map((booking) => {return <RenterBookingCard key={booking.id} id={booking.id} booking={booking}/>})
 
   }
-  console.log(props.bookings)
+
+  const getPastBookings = () => {
+    const today = new Date(new Date().toDateString());
+    const pastBookings = props.bookings.filter((booking) => {
+      return new Date(booking.date) < today;
+    });
+    pastBookings.sort((a, b) => {
+      a = new Date(a.date);
+      b = new Date(b.date);
+      if (a > b) {
+        return -1;
+      } else if (b < a) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+    return pastBookings.map((booking) => {return <RenterBookingCard key={booking.id} id={booking.id} booking={booking}/>})
+
+  }
 
   return (
     <div className="results-container">
       <h2>Upcoming Bookings:</h2>
       {getFutureBookings()}
       <h2>Past Bookings:</h2>
-      {/* <RenterBookingCard />
-      <RenterBookingCard />
-      <RenterBookingCard />
-      <RenterBookingCard /> */}
+      {getPastBookings()}
     </div>
   );
 };

--- a/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
+++ b/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
@@ -22,6 +22,7 @@ const RenterBookingsContainer = (props) => {
     return futureBookings.map((booking) => {return <RenterBookingCard key={booking.id} id={booking.id} booking={booking}/>})
 
   }
+  console.log(props.bookings)
 
   return (
     <div className="results-container">

--- a/src/Components/RenterResultCard/RenterResultCard.js
+++ b/src/Components/RenterResultCard/RenterResultCard.js
@@ -11,7 +11,7 @@ const RenterResultCard = (props) => {
     history.push("/dashboard")
   }
 
-  const [createBooking, {}] = useMutation(createNewBooking, {
+  const [createBooking] = useMutation(createNewBooking, {
     refetchQueries:[{
       query:getBookingsForMusician(2)}, {query:getRoomsByDate(props.date)}]
   })

--- a/src/Components/RenterResultCard/RenterResultCard.js
+++ b/src/Components/RenterResultCard/RenterResultCard.js
@@ -1,5 +1,4 @@
 import "./RenterResultCard.css";
-import housepic from "../../Images/house.png";
 import { Link, useHistory } from "react-router-dom";
 import { useMutation } from "@apollo/client";
 import { createNewBooking, getBookingsForMusician, getRoomsByDate } from "../../queries";
@@ -12,7 +11,7 @@ const RenterResultCard = (props) => {
     history.push("/dashboard")
   }
 
-  const [createBooking, {data, loading, error}] = useMutation(createNewBooking, {
+  const [createBooking, {}] = useMutation(createNewBooking, {
     refetchQueries:[{
       query:getBookingsForMusician(2)}, {query:getRoomsByDate(props.date)}]
   })

--- a/src/Components/RoomView/RoomView.js
+++ b/src/Components/RoomView/RoomView.js
@@ -10,7 +10,7 @@ const RoomView = ({ room, date }) => {
   //   createBooking({ variables: createTestObject()})
   // }
 
-  const [createBooking, {}] = useMutation(createNewBooking, {
+  const [createBooking] = useMutation(createNewBooking, {
     refetchQueries:[{
       query:getBookingsForMusician(2)}, {query:getRoomsByDate(date)}]
   })

--- a/src/Components/RoomView/RoomView.js
+++ b/src/Components/RoomView/RoomView.js
@@ -10,7 +10,7 @@ const RoomView = ({ room, date }) => {
   //   createBooking({ variables: createTestObject()})
   // }
 
-  const [createBooking, {data, loading, error}] = useMutation(createNewBooking, {
+  const [createBooking, {}] = useMutation(createNewBooking, {
     refetchQueries:[{
       query:getBookingsForMusician(2)}, {query:getRoomsByDate(date)}]
   })
@@ -18,7 +18,6 @@ const RoomView = ({ room, date }) => {
     return {date: `${date}`, musicianId: "2", roomId: `${room.id}`}
   }
   
-  console.log(date)
   return (
     <>
       <div className="detailed-view-container">

--- a/src/Pages/Booking/Booking.js
+++ b/src/Pages/Booking/Booking.js
@@ -4,7 +4,7 @@ import {getIndividualRoom} from "../../queries";
 import {useQuery} from '@apollo/client';
 
 const Booking = (props) => {
-  const {loading, data, error} = useQuery(getIndividualRoom(props.id))
+  const {loading, data} = useQuery(getIndividualRoom(props.id))
 
 
   return (

--- a/src/Pages/Dashboard/Dashboard.js
+++ b/src/Pages/Dashboard/Dashboard.js
@@ -5,7 +5,7 @@ import { useQuery } from "@apollo/client";
 
 
 const Dashboard = () => {
-  const {loading, data, error} = useQuery(getBookingsForMusician(2))//LONGTERM FIGURE OUT HOW TO MAKE THIS DYNAMIC ACCORDING TO LOG IN INFO!
+  const {loading, data} = useQuery(getBookingsForMusician(2))//LONGTERM FIGURE OUT HOW TO MAKE THIS DYNAMIC ACCORDING TO LOG IN INFO!
 
 
   return (

--- a/src/Pages/Search/Search.js
+++ b/src/Pages/Search/Search.js
@@ -7,7 +7,7 @@ import { useQuery } from "@apollo/client";
 
 const Search = (props) => {
   // const [date, setDate] = useState(new Date(new Date().toLocaleDateString()).toJSON());
-  const { loading, data, error } = useQuery(getRoomsByDate(props.date));
+  const { loading, data } = useQuery(getRoomsByDate(props.date));
   const [availableInstSelect, setAvailableInstSelect] = useState([]);
   const [availableAmenSelect, setAvailableAmenSelect] = useState([]);
   const [sortSelect, setSortSelect] = useState({

--- a/src/queries.js
+++ b/src/queries.js
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 const getRoomsByDate = (date) => gql`
   {
-    query getAvailableRooms(date: "${date}") {
+    getAvailableRooms(date: "${date}") {
       id
       name
       photo
@@ -14,7 +14,7 @@ const getRoomsByDate = (date) => gql`
 
 const getIndividualRoom = (id) => gql`
   {
-    query getRoom(id: "${id}") {
+    getRoom(id: "${id}") {
       id
       name
       details
@@ -32,7 +32,7 @@ const getIndividualRoom = (id) => gql`
 
 const getBookingsForMusician = (musicianId) => gql`
   { 
-    query getMusicianBookings(id: "${musicianId}")
+    getMusicianBookings(id: "${musicianId}")
         {
           id
           date


### PR DESCRIPTION
- Commit message(s) added to this PR:
  - [Display past bookings as well as future](https://github.com/Rum-Project/ruum-fe/commit/35b1e5c98d4d2c1b8d9957e1cf9a2217bfee010d)

- Why is this change necessary (explain like I'm 5)?
  - Our site up until this point only displayed future bookings, we needed to display past bookings as well 

- What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
  - The "display future bookings" function was copied, with some minor edits made to it in order to sort past bookings rather than future bookings

- Why did we make this change? What Changed? How do we test it?
  - Go to the bookings page. There should be at least one past booking displayed
