### PR TITLE
Refactor/add past bookings

### DIFF
--- a/cypress/integration/filter-bar-spec.js
+++ b/cypress/integration/filter-bar-spec.js
@@ -1,6 +1,0 @@
-describe("Test file", () => {
-  it("Should be able to say true is equal to true", () => {
-    cy.visit("http://localhost:3000/");
-    expect(true).to.equal(true);
-  });
-});

--- a/cypress/integration/test-spec.js
+++ b/cypress/integration/test-spec.js
@@ -1,6 +1,6 @@
-describe("Test file", () => {
-  it("Should be able to say true is equal to true", () => {
-    cy.visit("http://localhost:3000/");
-    expect(true).to.equal(true);
-  });
-});
+// describe("Test file", () => {
+//   it("Should be able to say true is equal to true", () => {
+//     cy.visit("http://localhost:3000/");
+//     expect(true).to.equal(true);
+//   });
+// });

--- a/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
+++ b/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
@@ -2,7 +2,6 @@ import "./RenterBookingsContainer.css";
 import RenterBookingCard from "../RenterBookingCard/RenterBookingCard";
 
 const RenterBookingsContainer = (props) => {
-
   const getFutureBookings = () => {
     const today = new Date(new Date().toDateString());
     const futureBookings = props.bookings.filter((booking) => {
@@ -19,9 +18,35 @@ const RenterBookingsContainer = (props) => {
         return 0;
       }
     });
-    return futureBookings.map((booking) => {return <RenterBookingCard key={booking.id} id={booking.id} booking={booking}/>})
+    return futureBookings.map((booking) => {
+      return (
+        <RenterBookingCard key={booking.id} id={booking.id} booking={booking} />
+      );
+    });
+  };
 
-  }
+  const getPastBookings = () => {
+    const today = new Date(new Date().toDateString());
+    const pastBookings = props.bookings.filter((booking) => {
+      return new Date(booking.date) < today;
+    });
+    pastBookings.sort((a, b) => {
+      a = new Date(a.date);
+      b = new Date(b.date);
+      if (a < b) {
+        return 1;
+      } else if (b < a) {
+        return -1;
+      } else {
+        return 0;
+      }
+    });
+    return pastBookings.map((booking) => {
+      return (
+        <RenterBookingCard key={booking.id} id={booking.id} booking={booking} />
+      );
+    });
+  };
 
   const getPastBookings = () => {
     const today = new Date(new Date().toDateString());

--- a/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
+++ b/src/Components/RenterBookingsContainer/RenterBookingsContainer.js
@@ -33,10 +33,10 @@ const RenterBookingsContainer = (props) => {
     pastBookings.sort((a, b) => {
       a = new Date(a.date);
       b = new Date(b.date);
-      if (a < b) {
-        return 1;
-      } else if (b < a) {
+      if (a > b) {
         return -1;
+      } else if (b < a) {
+        return 1;
       } else {
         return 0;
       }
@@ -47,26 +47,6 @@ const RenterBookingsContainer = (props) => {
       );
     });
   };
-
-  const getPastBookings = () => {
-    const today = new Date(new Date().toDateString());
-    const pastBookings = props.bookings.filter((booking) => {
-      return new Date(booking.date) < today;
-    });
-    pastBookings.sort((a, b) => {
-      a = new Date(a.date);
-      b = new Date(b.date);
-      if (a > b) {
-        return -1;
-      } else if (b < a) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
-    return pastBookings.map((booking) => {return <RenterBookingCard key={booking.id} id={booking.id} booking={booking}/>})
-
-  }
 
   return (
     <div className="results-container">

--- a/src/Utils/graphql-test-utils.js
+++ b/src/Utils/graphql-test-utils.js
@@ -10,22 +10,7 @@ export const hasOperationName = (req, operationName) => {
 
 // Alias query if operationName matches
 export const aliasQuery = (req, operationName, fixture) => {
-  //   if (
-  //     hasOperationName(req, operationName) &&
-  //     operationName === "getAvailableRooms"
-  //   ) {
-  //     req.alias = `gql${operationName}Query`;
-  //     req.reply((res) => {
-  //       res.body.data = roomcardFixture;
-  //     });
-  //   }
-  //   if (hasOperationName(req, operationName) && operationName === "getRoom") {
-  //     req.body.variables.id = 1;
-  //     req.alias = `gql${operationName}Query`;
-  //     req.reply((res) => {
-  //       res.body.data = roomDetailsFixture;
-  //     });
-  //   }
+
   if (
     req.body.hasOwnProperty("query") &&
     req.body.query.includes(operationName)


### PR DESCRIPTION
*Rebase Attempt* 

- Commit message(s) added to this PR:
  - Remove unused code
  - Add past bookings logic
  - Remove duplicate
  
- Why is this change necessary (explain like I'm 5)?
  - We needed the logic to filter our bookings into past bookings for the UI on the bookings dashboard.
  
- What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
  - Added an extra function to handle filtering the bookings into "past bookings"
  
- Why did we make this change? What Changed? How do we test it?
  - We needed this logic as part of the user experience. Just added an extra function for the logic. It can be tested by looking at the Bookings dashboard page and checking that the dates are "past" from today.